### PR TITLE
Updating reported client version

### DIFF
--- a/game/src/Archipelago/AP.cpp
+++ b/game/src/Archipelago/AP.cpp
@@ -197,7 +197,7 @@ void AP::connect()
 	m_info.patcher->set_enable_collision_warnings(false);
 	m_info.patcher->print_usage();
 
-	AP_NetworkVersion version = {0, 4, 3};
+	AP_NetworkVersion version = {0, 5, 0};
 	AP_SetClientVersion(&version);
     AP_Init(m_info.address.c_str(), "Faxanadu", m_info.slot_name.c_str(), m_info.password.c_str());
 	AP_SetDeathLinkSupported(true);


### PR DESCRIPTION
This is my understanding of why Daxanadu currently doesn't work with 0.6.2 webserver:

AP was updated to change datapackages so that games do not have to worry about overlapping ids with other games within the AP ecosystem.  As that landed in release 0.5.0, the minimum client version that theoretically supports this is 0.5.0.  Daxanadu currently reports 0.4.3, and so is reporting a version that theoretically does not support interacting with the datapackage by segregating by game then by id.

0.6.2 finally decided to enforce this change, and thus bumped the minimum expected client version on connection with the AP server.

That being said, the submodule ref for the library Daxanadu uses to connect to AP is dated Nov 2023, while the library was updated in Oct 2023 to support this feature.  So unless Daxanadu is doing something odd with how it handles the datapackage, bumping the version should be adequate.